### PR TITLE
Refactor store internals

### DIFF
--- a/napari_lazy_openslide/_tests/test_lazy_openslide.py
+++ b/napari_lazy_openslide/_tests/test_lazy_openslide.py
@@ -1,6 +1,8 @@
-import numpy as np
-from napari_lazy_openslide import napari_get_reader
 from pathlib import Path
+
+import numpy as np
+
+from napari_lazy_openslide import napari_get_reader
 
 fixture_dir = Path.cwd() / ".." / ".." / "fixtures"
 

--- a/napari_lazy_openslide/lazy_openslide.py
+++ b/napari_lazy_openslide/lazy_openslide.py
@@ -74,8 +74,9 @@ class OpenSlideStore:
         )
         for level in range(levels):
             xshape, yshape = self._slide.level_dimensions[level]
-            meta = dict(shape=(yshape, xshape, 4), **base_meta)
-            d[str(level) + "/" + array_meta_key] = encode_array_metadata(meta)
+            arr_key = str(level) + "/" + array_meta_key
+            arr_meta = dict(shape=(yshape, xshape, 4), **base_meta)
+            d[arr_key] = encode_array_metadata(arr_meta)
         return d
 
     def keys(self):

--- a/napari_lazy_openslide/lazy_openslide.py
+++ b/napari_lazy_openslide/lazy_openslide.py
@@ -1,13 +1,14 @@
-import numpy as np
-from napari_plugin_engine import napari_hook_implementation
-from openslide import OpenSlide, OpenSlideUnsupportedFormatError, PROPERTY_NAME_COMMENT
-import dask.array as da
 from pathlib import Path
 
+import numpy as np
+
+import dask.array as da
 import zarr
-from zarr.util import json_dumps
-from zarr.storage import array_meta_key, group_meta_key, attrs_key
+from napari_plugin_engine import napari_hook_implementation
+from openslide import PROPERTY_NAME_COMMENT, OpenSlide, OpenSlideUnsupportedFormatError
 from zarr.meta import encode_array_metadata, encode_group_metadata
+from zarr.storage import array_meta_key, attrs_key, group_meta_key
+from zarr.util import json_dumps
 
 
 def encode_root_attrs(levels):


### PR DESCRIPTION
This PR replaces the hardcoded Zarr metadata utils with those provided by `zarr-python`. 