### PR TITLE
depend on the official openslide-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ napari-plugin-engine>=0.1.4
 numpy>=0.1.19
 zarr>=0.2.4
 dask[array]>=2.20.0
-openslide-wrapper==1.1.2
+openslide-python==1.1.2


### PR DESCRIPTION
openslide-python 1.1.2 has been officially released, so there is no need anymore for the wrapper hack

closes #3