### PR TITLE
OpenSlideStore serialization

### DIFF
--- a/napari_lazy_openslide/store.py
+++ b/napari_lazy_openslide/store.py
@@ -131,10 +131,9 @@ class OpenSlideStore(BaseStore):
         return {"_path": self._path, "_tilesize": self._tilesize}
 
     def __setstate__(self, newstate):
-        self._path = newstate["_path"]
-        self._tilesize = newstate["_tilesize"]
-        self._slide = OpenSlide(self._path)
-        self._store = create_meta_store(self._slide, self._tilesize)
+        path = newstate["_path"]
+        tilesize = newstate["_tilesize"]
+        self.__init__(path, tilesize)
 
 
 if __name__ == "__main__":

--- a/napari_lazy_openslide/store.py
+++ b/napari_lazy_openslide/store.py
@@ -47,6 +47,7 @@ def _parse_chunk_path(path: str):
     y, x, _ = map(int, ckey.split("."))
     return x, y, int(level)
 
+
 class OpenSlideStore(BaseStore):
     """Wraps an OpenSlide object as a multiscale Zarr Store.
 
@@ -59,6 +60,7 @@ class OpenSlideStore(BaseStore):
     """
 
     def __init__(self, path: str, tilesize: int = 512):
+        self._path = path
         self._slide = OpenSlide(path)
         self._tilesize = tilesize
         self._store = create_meta_store(self._slide, tilesize)
@@ -124,6 +126,15 @@ class OpenSlideStore(BaseStore):
 
     def close(self):
         self._slide.close()
+
+    def __getstate__(self):
+        return {"_path": self._path, "_tilesize": self._tilesize}
+
+    def __setstate__(self, newstate):
+        self._path = newstate["_path"]
+        self._tilesize = newstate["_tilesize"]
+        self._slide = OpenSlide(self._path)
+        self._store = create_meta_store(self._slide, self._tilesize)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR makes the OpenSlideStore objects seriazable, so that they can be used in a Dask cluster. Serialization is implemented in __setstate__ and __getstate__.

At this moment, this code:

```
from dask.distributed import Client
c = Client()
import dask.array as da
import zarr

from napari_lazy_openslide import OpenSlideStore

store = OpenSlideStore('../data/normal_001.tif')
grp = zarr.open(store, mode="r")

datasets = grp.attrs["multiscales"][0]["datasets"]
pyramid = [da.from_zarr(store, component=d["path"]) for d in datasets]
pyramid[0][:10,:10].compute()
```
raises ```TypeError: ('Could not serialize object of type Array', "<zarr.core.Array '/0' (221184, 97792, 4) uint8 read-only>")```.

This PR solves the issue.