### PR TITLE
Fix zarr>2.14

### DIFF
--- a/napari_lazy_openslide/store.py
+++ b/napari_lazy_openslide/store.py
@@ -86,6 +86,9 @@ class OpenSlideStore(Store):
 
         return np.array(tile).tobytes()
 
+    def getitems(self, keys):
+        return {k: self[k] for k in keys}
+
     def __contains__(self, key: str):
         return key in self._store
 

--- a/napari_lazy_openslide/store.py
+++ b/napari_lazy_openslide/store.py
@@ -86,7 +86,7 @@ class OpenSlideStore(Store):
 
         return np.array(tile).tobytes()
 
-    def getitems(self, keys):
+    def getitems(self, keys, *, contexts):
         return {k: self[k] for k in keys}
 
     def __contains__(self, key: str):

--- a/napari_lazy_openslide/store.py
+++ b/napari_lazy_openslide/store.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, Mapping, MutableMapping
 import numpy as np
 from openslide import OpenSlide
 
-from zarr.storage import _path_to_prefix, attrs_key, init_array, init_group, BaseStore
+from zarr.storage import _path_to_prefix, attrs_key, init_array, init_group, Store
 from zarr.util import json_dumps, normalize_storage_path
 
 
@@ -47,7 +47,7 @@ def _parse_chunk_path(path: str):
     y, x, _ = map(int, ckey.split("."))
     return x, y, int(level)
 
-class OpenSlideStore(BaseStore):
+class OpenSlideStore(Store):
     """Wraps an OpenSlide object as a multiscale Zarr Store.
 
     Parameters


### PR DESCRIPTION
Thanks for creating this!

This PR is to add `getitems` method to the SVS store for compatibility with zarr > 2.14.

Zarr PR that broke (https://github.com/manzt/napari-lazy-openslide/issues/18) the current store: https://github.com/zarr-developers/zarr-python/pull/1131
